### PR TITLE
Only flush varnish from CLI when specific drush command is ran

### DIFF
--- a/acquia_purge_d8cache.drush.inc
+++ b/acquia_purge_d8cache.drush.inc
@@ -24,7 +24,7 @@ function acquia_purge_d8cache_drush_command() {
  */
 function drush_acquia_purge_d8cache_clear_site() {
   $ipv4_addresses = _acquia_purge_d8cache_get_balancers();
-  // Perform a full site varnish flush when Drupal site caches are cleared.
+  // Perform a full site varnish flush.
   foreach ($ipv4_addresses as $ipv4) {
     _acquia_purge_d8cache_curl_request("http://$ipv4/site", [], TRUE);
   }

--- a/acquia_purge_d8cache.drush.inc
+++ b/acquia_purge_d8cache.drush.inc
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * @file
+ * acquia_purge_d8cache.drush.inc
+ */
+
+/**
+ * Implements hook_drush_command().
+ */
+function acquia_purge_d8cache_drush_command() {
+  $items = [];
+  // Clear all varnish cache command.
+  $items['apd8cache-flush'] = [
+    'description' => "Clear the Acquia Varnish cache for the site.",
+    'aliases' => ['apd8f'],
+    'bootstrap' => DRUSH_BOOTSTRAP_DRUPAL_FULL,
+  ];
+  return $items;
+}
+
+/**
+ * Drush callback to clear full site varnish caches.
+ */
+function drush_acquia_purge_d8cache_clear_site() {
+  $ipv4_addresses = _acquia_purge_d8cache_get_balancers();
+  // Perform a full site varnish flush when Drupal site caches are cleared.
+  foreach ($ipv4_addresses as $ipv4) {
+    _acquia_purge_d8cache_curl_request("http://$ipv4/site", [], TRUE);
+  }
+}

--- a/acquia_purge_d8cache.drush.inc
+++ b/acquia_purge_d8cache.drush.inc
@@ -22,7 +22,7 @@ function acquia_purge_d8cache_drush_command() {
 /**
  * Drush callback to clear full site varnish caches.
  */
-function drush_acquia_purge_d8cache_clear_site() {
+function drush_acquia_purge_d8cache_apd8cache_flush() {
   $ipv4_addresses = _acquia_purge_d8cache_get_balancers();
   // Perform a full site varnish flush.
   foreach ($ipv4_addresses as $ipv4) {

--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -45,7 +45,7 @@ function acquia_purge_d8cache_flush_caches() {
  */
 function acquia_purge_d8cache_form_views_ui_edit_display_form_alter(&$form, &$form_state, $form_id) {
   if (isset($form_state['section']) && $form_state['section'] == 'cache') {
-    // Prevent users from changing view cache settings since we disable them all.
+    // Prevent users from changing view cache settings since we disable them.
     $form = [
       '#markup' => t('<h2>Acquia Purge D8Cache module has disabled these settings.</h2>'),
     ];

--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -173,13 +173,20 @@ function acquia_purge_d8cache_cron() {
  *   Load balancer url.
  * @param array $tags
  *   Array of varnish tags to invalidate.
+ * @param bool $allow_cli
+ *   Flag to allow CLI commands make curl requests (drush command).
  */
-function _acquia_purge_d8cache_curl_request($url, array $tags = []) {
-  $options = _acquia_purge_d8cache_get_curl_options($url, $tags);
-  $ch = curl_init();
-  curl_setopt_array($ch, $options);
-  curl_exec($ch);
-  curl_close($ch);
+function _acquia_purge_d8cache_curl_request($url, array $tags = [], $allow_cli = FALSE) {
+  // Only flush varnish if caches are cleared via the UI or through the included
+  // drush command. This reduces the unnecessary invalidations when doing
+  // database updates through hooks.
+  if (PHP_SAPI !== 'cli' || $allow_cli) {
+    $options = _acquia_purge_d8cache_get_curl_options($url, $tags);
+    $ch = curl_init();
+    curl_setopt_array($ch, $options);
+    curl_exec($ch);
+    curl_close($ch);
+  }
 }
 
 /**


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Don't flush varnish unless something executed through the UI or a specific drush command
- New drush command to flush varnish for a full site easier.

# Needed By (Date)
- sooner the better.

# Urgency
- low

# Steps to Test
1. checkout branch
1. on local run `drush cc drush && drush | grep apd8cache`
1. verify the custom command is listed.
1. checkout this branch on a dev/test environment
1. verify varnish is cleared through the UI but not when you run  `drush cc all` on the site.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
