### PR TITLE
use UTC_TIMESTAMP instead of NOW

### DIFF
--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -149,7 +149,7 @@ function acquia_purge_d8cache_cron() {
     if ($field_info['type'] == 'datetime') {
       $query = db_select("field_data_$field_name", 'f')
         ->fields('f')
-        ->where("{$field_name}_value between '$last_cron_utc' and NOW()")
+        ->where("{$field_name}_value between '$last_cron_utc' and UTC_TIMESTAMP()")
         ->execute();
 
       while ($field_data = $query->fetchAssoc()) {


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- this doesn't really change anything on Acquia's database, but for local work the db might have a different timezone. `NOW()` returns local timezone. `UTC_TIMESTAMP()` return utc. and the field values are stored in UTC format.

# Needed By (Date)
- :man_shrugging: 

# Urgency
- low

# Steps to Test
1. :eyes: 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
