### PR TITLE
Entity list invalidate

### DIFF
--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -72,7 +72,7 @@ function acquia_purge_d8cache_views_pre_render(&$view) {
     foreach ($view->filter['type']->value as $bundle) {
       // Custom cache tags for when a new entity is created of the bundle that
       // this view is displaying.
-      $tags[] = "{$entity_type}_{$bundle}_create";
+      $tags[] = "{$entity_type}_{$bundle}_list";
     }
   }
   drupal_add_cache_tags($tags);
@@ -86,7 +86,7 @@ function acquia_purge_d8cache_entity_insert($entity, $type) {
   if ($bundle) {
     // Invalidate the custom cache tag for views.
     // @see acquia_purge_d8cache_views_pre_render()
-    $tags = ["{$type}_{$bundle}_create"];
+    $tags = ["{$type}_{$bundle}_list"];
     drupal_invalidate_cache_tags($tags);
   }
 }
@@ -273,5 +273,6 @@ function _acquia_purge_d8cache_get_site_name() {
  *   Cache tag.
  */
 function _acquia_purge_d8cache_hash_tag(&$tag) {
+  return;
   $tag = substr(hash('md5', $tag), 0, 4);
 }

--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -273,6 +273,5 @@ function _acquia_purge_d8cache_get_site_name() {
  *   Cache tag.
  */
 function _acquia_purge_d8cache_hash_tag(&$tag) {
-  return;
   $tag = substr(hash('md5', $tag), 0, 4);
 }


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Invalidate `{entity_type}_{bundle}_list` for views any time an entity is created or edited.
- this should also fix the date expiration invalidation since the cron flushes that cache tag at https://github.com/SU-SWS/acquia_purge_d8cache/blob/7.x-1.x/acquia_purge_d8cache.module#L160

# Need Review By (Date)
- sooner would be nice

# Urgency
- high

# Steps to Test
This is tough to test. reach out to me if you wanna demo/look at it

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
