### PR TITLE
HSD8-751 Allow cron to invalidate cache tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # Acquia Purge D8Cache
 
+7.x-1.4
+--------------------------------------------------------------------------------
+_Release Date: 2020-02-10_
+
+- Fixed the logic to allow varnish tags to be cleared during cron runs when executed via the CLI.
+
 7.x-1.3
 --------------------------------------------------------------------------------
 _Release Date: 2019-11-19_
 
 - Modified cache tags on views to be more apt to invalidation when content is edited.
-- Use UTC_TIMESTAMP() instead of NOW(). 
+- Use UTC_TIMESTAMP() instead of NOW().
 
 7.x-1.2
 --------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # [Acquia Purge D8Cache](https://github.com/SU-SWS/acquia_purge_d8cache)
-##### Version: 7.x-1.3
+##### Version: 7.x-1.4
 
 Maintainers: [pookmish](https://github.com/pookmish), [jbickar](https://github.com/jbickar),  [sherakama](https://github.com/sherakama)
 

--- a/acquia_purge_d8cache.info
+++ b/acquia_purge_d8cache.info
@@ -2,5 +2,5 @@ name = Acquia Purge D8 Cache
 description = Purge Acquia varnish caches using D8Cache module, which is a backport of D8 cache tag mechanism
 core = 7.x
 package = Stanford - ACSF
-version = 7.x-1.3
+version = 7.x-1.4
 dependencies[] = d8cache

--- a/acquia_purge_d8cache.module
+++ b/acquia_purge_d8cache.module
@@ -162,7 +162,7 @@ function acquia_purge_d8cache_cron() {
       }
     }
   }
-
+  drupal_static(__FUNCTION__, TRUE);
   drupal_invalidate_cache_tags(array_unique($tags));
 }
 
@@ -177,10 +177,13 @@ function acquia_purge_d8cache_cron() {
  *   Flag to allow CLI commands make curl requests (drush command).
  */
 function _acquia_purge_d8cache_curl_request($url, array $tags = [], $allow_cli = FALSE) {
+  // If the cron hook has fired, make sure to allow the curl request to work.
+  $during_cron = drupal_static('acquia_purge_d8cache_cron', FALSE);
+
   // Only flush varnish if caches are cleared via the UI or through the included
   // drush command. This reduces the unnecessary invalidations when doing
   // database updates through hooks.
-  if (PHP_SAPI !== 'cli' || $allow_cli) {
+  if (PHP_SAPI !== 'cli' || $allow_cli || $during_cron) {
     $options = _acquia_purge_d8cache_get_curl_options($url, $tags);
     $ch = curl_init();
     curl_setopt_array($ch, $options);


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Cron right now doesn't actually clear any varnish tags unless its ran through the UI. This fixes that
- Increments the release.

# Need Review By (Date)
- asap

# Urgency
- medium

# Steps to Test
1. if its not clear, i can show on my local.

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)
